### PR TITLE
add refetch option to usePaginatedQuery

### DIFF
--- a/src/client/vue-composables/use-paginated-query.ts
+++ b/src/client/vue-composables/use-paginated-query.ts
@@ -53,7 +53,7 @@ const usePaginatedQuery = <
 
   const variables = ref(defaultVariables) as Ref<Variables>
 
-  const { result, loading } = useQuery<
+  const { result, loading, refetch } = useQuery<
     Record<keyof Query, { records: Entity[]; total: number }>,
     Variables
   >(
@@ -105,7 +105,7 @@ const usePaginatedQuery = <
     variables.value.offset = event.page.skip
   }
 
-  return { variables, loading, records, total, pageTo, onKendoPageChange }
+  return { variables, loading, records, total, refetch, pageTo, onKendoPageChange }
 }
 
 export default usePaginatedQuery


### PR DESCRIPTION
On Jilc, there is problem with grids, which are using usePaginatedQuery. When you update grid data, you need to refresh page to make this data visible, I propose to add refetch option to to refresh data without page loading